### PR TITLE
Fixed unsafe property reading to be compatible with Gradle parallel build

### DIFF
--- a/src/main/kotlin/dev/architectury/plugin/ArchitecturyPluginExtension.kt
+++ b/src/main/kotlin/dev/architectury/plugin/ArchitecturyPluginExtension.kt
@@ -10,6 +10,7 @@ import dev.architectury.transformer.shadowed.impl.com.google.gson.Gson
 import dev.architectury.transformer.shadowed.impl.com.google.gson.JsonObject
 import dev.architectury.transformer.transformers.BuiltinProperties
 import dev.architectury.transformer.transformers.properties.TransformersWriter
+import dev.architectury.transformer.util.Logger
 import dev.architectury.transformer.util.TransformerPair
 import org.gradle.api.Action
 import org.gradle.api.Project
@@ -94,7 +95,7 @@ open class ArchitectPluginExtension(val project: Project) {
     }
 
     fun properties(platform: String): Map<String, String> {
-        return mutableMapOf(
+        return mapOf(
             BuiltinProperties.MIXIN_MAPPINGS to loom.allMixinMappings.joinToString(File.pathSeparator),
             BuiltinProperties.INJECT_INJECTABLES to injectInjectables.toString(),
             BuiltinProperties.UNIQUE_IDENTIFIER to project.projectUniqueIdentifier(),
@@ -391,7 +392,7 @@ open class ArchitectPluginExtension(val project: Project) {
                         val output = it.archiveFile.get().asFile
 
                         try {
-                            OpenedFileAccess.ofJar(output.toPath()).use { inter ->
+                            OpenedFileAccess.ofJar(Logger.getDefaultLogger(), output.toPath()).use { inter ->
                                 inter.addFile("architectury.common.marker", "")
                             }
                         } catch (t: Throwable) {

--- a/src/main/kotlin/dev/architectury/plugin/transformers/AddRefmapName.kt
+++ b/src/main/kotlin/dev/architectury/plugin/transformers/AddRefmapName.kt
@@ -7,7 +7,6 @@ import dev.architectury.transformer.input.FileAccess
 import dev.architectury.transformer.transformers.BuiltinProperties
 import dev.architectury.transformer.transformers.base.AssetEditTransformer
 import dev.architectury.transformer.transformers.base.edit.TransformerContext
-import dev.architectury.transformer.util.Logger
 import java.io.ByteArrayInputStream
 
 class AddRefmapName : AssetEditTransformer {
@@ -19,7 +18,7 @@ class AddRefmapName : AssetEditTransformer {
             if (path.endsWith(".json") && !Transform.trimLeadingSlash(path)
                     .contains("/") && !Transform.trimLeadingSlash(path).contains("\\")
             ) {
-                Logger.debug("Checking whether $path is a mixin config.")
+                context.logger.debug("Checking whether $path is a mixin config.")
                 try {
                     val json = gson.fromJson(ByteArrayInputStream(bytes).reader(), JsonObject::class.java)
                     if (json != null) {
@@ -37,7 +36,7 @@ class AddRefmapName : AssetEditTransformer {
             }
         }
         if (mixins.isNotEmpty()) {
-            Logger.debug("Found mixin config(s): " + java.lang.String.join(",", mixins))
+            context.logger.debug("Found mixin config(s): " + java.lang.String.join(",", mixins))
         }
         val refmap = System.getProperty(BuiltinProperties.REFMAP_NAME)
         mixins.forEach { path ->
@@ -48,7 +47,7 @@ class AddRefmapName : AssetEditTransformer {
                 )
 
                 if (!json.has("refmap")) {
-                    Logger.debug("Injecting $refmap to $path")
+                    context.logger.debug("Injecting $refmap to $path")
                     json.addProperty("refmap", refmap)
                 }
 

--- a/src/main/kotlin/dev/architectury/plugin/transformers/AddRefmapName.kt
+++ b/src/main/kotlin/dev/architectury/plugin/transformers/AddRefmapName.kt
@@ -38,10 +38,10 @@ class AddRefmapName : AssetEditTransformer {
         if (mixins.isNotEmpty()) {
             context.logger.debug("Found mixin config(s): " + java.lang.String.join(",", mixins))
         }
-        val refmap = System.getProperty(BuiltinProperties.REFMAP_NAME)
+        val refmap = context.getProperty(BuiltinProperties.REFMAP_NAME)
         mixins.forEach { path ->
             output.modifyFile(path) {
-                val json: JsonObject = gson.fromJson<JsonObject>(
+                val json = gson.fromJson(
                     ByteArrayInputStream(it).reader(),
                     JsonObject::class.java
                 )


### PR DESCRIPTION
See https://github.com/architectury/architectury-transformer/pull/16
Replace Java environment property access with property access provided by `TransformerContext`. This should fix problems with Gradle parallel build (`org.gradle.parallel`) such as wrong refmaps getting placed in the jar.