### PR TITLE
Fix plugin not applying plugins as intended

### DIFF
--- a/src/main/kotlin/dev/architectury/plugin/ArchitecturyPlugin.kt
+++ b/src/main/kotlin/dev/architectury/plugin/ArchitecturyPlugin.kt
@@ -21,14 +21,10 @@ class ArchitecturyPlugin : Plugin<Project> {
 
         LoggerFilter.replaceSystemOut()
 
-        project.apply(
-            mapOf(
-                "plugin" to "java",
-                "plugin" to "eclipse",
-                "plugin" to "idea",
-                "plugin" to "org.jetbrains.gradle.plugin.idea-ext"
-            )
-        )
+        project.pluginManager.apply( "java" )
+        project.pluginManager.apply( "eclipse" )
+        project.pluginManager.apply( "idea" )
+        project.pluginManager.apply( "org.jetbrains.gradle.plugin.idea-ext" )
 
         project.afterEvaluate {
             val ideaModel = project.extensions.getByName("idea") as IdeaModel


### PR DESCRIPTION
when the architectury plugin is applied, it tries to apply 4 more plugins ( `java`, `eclipse`, `idea` and `org.jetbrains.gradle.plugin.idea-ext` ), but the way it was done caused only the last one ( `org.jetbrains.gradle.plugin.idea-ext` ) to actually apply, as maps cannot contain more than one value for a specific key, this PR fixes this by using the `project.pluginManager.apply()` method to apply each plugin individually.