### PR TITLE
Write transformer properties with UTF-8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,5 @@ loom_version_010Legacy=0.10.0.171
 loom_version_010=0.10.0.188
 loom_version_011=0.11.0.217
 loom_version_11=1.1.313
-transformer_version=5.2.72
+transformer_version=5.2.75
 base_version=3.4

--- a/src/main/kotlin/dev/architectury/plugin/ArchitecturyPluginExtension.kt
+++ b/src/main/kotlin/dev/architectury/plugin/ArchitecturyPluginExtension.kt
@@ -132,7 +132,7 @@ open class ArchitectPluginExtension(val project: Project) {
             properties(transforms.keys.first()).forEach { (key, value) ->
                 properties.setProperty(key, value)
             }
-            propertiesTransformerFile.writer().use {
+            propertiesTransformerFile.writer(Charsets.UTF_8).use {
                 properties.store(it, "Architectury Runtime Transformer Properties")
             }
         }

--- a/src/main/kotlin/dev/architectury/plugin/ArchitecturyPluginExtension.kt
+++ b/src/main/kotlin/dev/architectury/plugin/ArchitecturyPluginExtension.kt
@@ -30,7 +30,7 @@ import java.util.jar.JarOutputStream
 import java.util.jar.Manifest
 
 open class ArchitectPluginExtension(val project: Project) {
-    var transformerVersion = "5.2.72"
+    var transformerVersion = "5.2.75"
     var injectablesVersion = "1.0.10"
     var minecraft = ""
     private var compileOnly = false


### PR DESCRIPTION
Requires architectury/architectury-transformer#18 for UTF-8 support.

This is almost always the default behaviour (ISO-Latin-1 is only used on Windows + old Java). This fixes issues with arbitrary Unicode characters in transformer properties such as file paths.