### PR TITLE
Add ArchitecturyPluginExtension.fromCommon

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ loom_version_010=0.10.0.188
 loom_version_011=0.11.0.217
 loom_version_11=1.1.313
 transformer_version=5.2.81
-base_version=3.4
+base_version=4.0

--- a/src/main/java/dev/architectury/plugin/FromCommonSettings.java
+++ b/src/main/java/dev/architectury/plugin/FromCommonSettings.java
@@ -1,0 +1,69 @@
+package dev.architectury.plugin;
+
+import dev.architectury.plugin.utils.ClosureAction;
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
+import org.gradle.api.Action;
+import org.gradle.api.file.CopySpec;
+import org.gradle.api.provider.Property;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public interface FromCommonSettings {
+    /**
+     * The configuration for bundling common projects.
+     */
+    Property<BundleSettings> getBundle();
+
+    /**
+     * Configures the bundle settings.
+     *
+     * @param action the action that configures them
+     */
+    default void bundle(Action<BundleSettings> action) {
+        Objects.requireNonNull(action, "Action cannot be null");
+        action.execute(getBundle().get());
+    }
+
+    /**
+     * Configures the bundle settings.
+     *
+     * @param action the closure that configures them
+     */
+    default void bundle(@DelegatesTo(BundleSettings.class) Closure<?> action) {
+        Objects.requireNonNull(action, "Closure cannot be null");
+        bundle(new ClosureAction<>(action));
+    }
+
+    abstract class BundleSettings {
+        final List<Action<CopySpec>> configActions = new ArrayList<>(0);
+
+        /**
+         * Controls whether the common jar's contents are added to this project's
+         * {@code jar} task. True by default.
+         */
+        public abstract Property<Boolean> getEnabled();
+
+        /**
+         * Configures the bundling copy action.
+         *
+         * @param action the action that configures it
+         */
+        public void configure(Action<CopySpec> action) {
+            Objects.requireNonNull(action, "Action cannot be null");
+            configActions.add(action);
+        }
+
+        /**
+         * Configures the bundling copy action.
+         *
+         * @param action the closure that configures it
+         */
+        public void configure(@DelegatesTo(CopySpec.class) Closure<?> action) {
+            Objects.requireNonNull(action, "Closure cannot be null");
+            configure(new ClosureAction<>(action));
+        }
+    }
+}

--- a/src/main/java/dev/architectury/plugin/FromCommonSettings.java
+++ b/src/main/java/dev/architectury/plugin/FromCommonSettings.java
@@ -11,6 +11,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * Settings to configure {@link ArchitectPluginExtension#fromCommon(Object) architectury.fromCommon}.
+ */
 public interface FromCommonSettings {
     /**
      * The configuration for bundling common projects.
@@ -37,6 +40,9 @@ public interface FromCommonSettings {
         bundle(new ClosureAction<>(action));
     }
 
+    /**
+     * Settings to configure how common files are bundled.
+     */
     abstract class BundleSettings {
         final List<Action<CopySpec>> configActions = new ArrayList<>(0);
 
@@ -47,7 +53,7 @@ public interface FromCommonSettings {
         public abstract Property<Boolean> getEnabled();
 
         /**
-         * Configures the bundling copy action.
+         * Configures the {@link CopySpec} that bundles the common files.
          *
          * @param action the action that configures it
          */
@@ -57,7 +63,7 @@ public interface FromCommonSettings {
         }
 
         /**
-         * Configures the bundling copy action.
+         * Configures the {@link CopySpec} that bundles the common files.
          *
          * @param action the closure that configures it
          */

--- a/src/main/kotlin/dev/architectury/plugin/ArchitecturyPluginExtension.kt
+++ b/src/main/kotlin/dev/architectury/plugin/ArchitecturyPluginExtension.kt
@@ -4,6 +4,7 @@ package dev.architectury.plugin
 
 import dev.architectury.plugin.ModLoader.Companion.applyNeoForgeForgeLikeProd
 import dev.architectury.plugin.loom.LoomInterface
+import dev.architectury.plugin.utils.EmptyAction
 import dev.architectury.plugin.utils.GradleSupport
 import dev.architectury.transformer.Transformer
 import dev.architectury.transformer.input.OpenedFileAccess
@@ -13,6 +14,7 @@ import dev.architectury.transformer.shadowed.impl.com.google.gson.JsonObject
 import dev.architectury.transformer.transformers.BuiltinProperties
 import dev.architectury.transformer.transformers.properties.TransformersWriter
 import dev.architectury.transformer.util.TransformerPair
+import groovy.lang.Closure
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -38,6 +40,7 @@ open class ArchitectPluginExtension(val project: Project) {
     var injectInjectables = true
     var addCommonMarker = true
     private val transforms = mutableMapOf<String, Transform>()
+    private var loader: ModLoader? = null
     private var transformedLoom = false
     private val agentFile by lazy {
         project.gradle.rootProject.file(".gradle/architectury/architectury-transformer-agent.jar").also {
@@ -267,6 +270,7 @@ open class ArchitectPluginExtension(val project: Project) {
 
     @JvmOverloads
     fun loader(loader: ModLoader, action: Action<Transform> = Action {}) {
+        this.loader = loader
         transform(loader.id, Action {
             if (!compileOnly) {
                 loader.transformDevelopment(it)
@@ -478,6 +482,77 @@ open class ArchitectPluginExtension(val project: Project) {
         forgeLike {
             it.add(platforms)
             action(it)
+        }
+    }
+
+    /**
+     * Inherits this loader-specific project from a common project.
+     * This function also sets up bundling by default, which can be configured with the [action].
+     *
+     * The value of [commonProject] can be a [Project] object or a [CharSequence] of its path.
+     *
+     * This function must be called after the Architectury Plugin mod loader has been set.
+     */
+    @JvmOverloads
+    fun fromCommon(commonProject: Any?, action: Action<FromCommonSettings> = EmptyAction.cast()) {
+        val loader = this.loader
+            ?: throw IllegalStateException("architectury.fromCommon must be called after the loader has been set")
+
+        // Resolve the project
+        val (commonPath, common) = when (commonProject) {
+            is Project -> Pair(commonProject.path, commonProject)
+            is CharSequence -> {
+                val path = commonProject.toString()
+                Pair(path, project.project(path))
+            }
+            else -> throw IllegalArgumentException("Cannot convert value '$commonProject' to a Gradle project")
+        }
+
+        // Find the production jar from the common project.
+        val productionCommonJar = common.tasks.named(
+            "transformProduction${loader.titledId}",
+            TransformingTask::class.java
+        )
+
+        // Create settings object, initialise it with defaults and pass it through the action.
+        val settings = project.objects.newInstance(FromCommonSettings::class.java)
+        with(settings) {
+            val defaultBundle = project.objects.newInstance(FromCommonSettings.BundleSettings::class.java)
+            bundle.convention(defaultBundle)
+            defaultBundle.enabled.convention(true)
+            action.execute(this)
+        }
+
+        // Add compile + runtime dependency for the common project.
+        val commonDevDep = project.dependencies.project(
+            mapOf(
+                "path" to commonPath,
+                "configuration" to "namedElements"
+            )
+        )
+        if (commonDevDep is ModuleDependency) {
+            commonDevDep.isTransitive = false
+        }
+        project.dependencies.add(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, commonDevDep)
+
+        if (!compileOnly) {
+            // If not in compile-only mode, also add it to the transform-related configuration.
+            // Note: relies on the transform having the same id as the loader.
+            val devConfig = transforms.getValue(loader.id).devConfigName
+            project.dependencies.add(devConfig, commonDevDep)
+        }
+
+        // Set up bundling.
+        val bundle = settings.bundle.get()
+        if (bundle.enabled.get()) {
+            project.tasks.named(JavaPlugin.JAR_TASK_NAME, Jar::class.java) {
+                it.dependsOn(productionCommonJar)
+                it.from(project.zipTree(productionCommonJar.flatMap { jar -> jar.archiveFile })) { spec ->
+                    for (copyAction in bundle.configActions) {
+                        copyAction.execute(spec)
+                    }
+                }
+            }
         }
     }
 }

--- a/src/main/kotlin/dev/architectury/plugin/ArchitecturyPluginExtension.kt
+++ b/src/main/kotlin/dev/architectury/plugin/ArchitecturyPluginExtension.kt
@@ -14,7 +14,6 @@ import dev.architectury.transformer.shadowed.impl.com.google.gson.JsonObject
 import dev.architectury.transformer.transformers.BuiltinProperties
 import dev.architectury.transformer.transformers.properties.TransformersWriter
 import dev.architectury.transformer.util.TransformerPair
-import groovy.lang.Closure
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.Task

--- a/src/main/kotlin/dev/architectury/plugin/utils/ClosureAction.kt
+++ b/src/main/kotlin/dev/architectury/plugin/utils/ClosureAction.kt
@@ -3,7 +3,7 @@ package dev.architectury.plugin.utils
 import groovy.lang.Closure
 import org.gradle.api.Action
 
-class ClosureAction<T>(private val closure: Closure<*>) : Action<T> {
+internal class ClosureAction<T>(private val closure: Closure<*>) : Action<T> {
     override fun execute(value: T) {
         closure.delegate = value
         closure.call(value)

--- a/src/main/kotlin/dev/architectury/plugin/utils/ClosureAction.kt
+++ b/src/main/kotlin/dev/architectury/plugin/utils/ClosureAction.kt
@@ -1,0 +1,11 @@
+package dev.architectury.plugin.utils
+
+import groovy.lang.Closure
+import org.gradle.api.Action
+
+class ClosureAction<T>(private val closure: Closure<*>) : Action<T> {
+    override fun execute(value: T) {
+        closure.delegate = value
+        closure.call(value)
+    }
+}

--- a/src/main/kotlin/dev/architectury/plugin/utils/EmptyAction.kt
+++ b/src/main/kotlin/dev/architectury/plugin/utils/EmptyAction.kt
@@ -1,0 +1,11 @@
+package dev.architectury.plugin.utils
+
+import org.gradle.api.Action
+
+internal object EmptyAction : Action<Nothing> {
+    override fun execute(value: Nothing) {
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T> cast(): Action<T> = this as Action<T>
+}

--- a/src/main/kotlin/dev/architectury/plugin/utils/EmptyAction.kt
+++ b/src/main/kotlin/dev/architectury/plugin/utils/EmptyAction.kt
@@ -2,8 +2,8 @@ package dev.architectury.plugin.utils
 
 import org.gradle.api.Action
 
-internal object EmptyAction : Action<Nothing> {
-    override fun execute(value: Nothing) {
+internal object EmptyAction : Action<Any?> {
+    override fun execute(value: Any?) {
     }
 
     @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
Basic usage example:
```gradle
architectury {
    // Sets up dev dependencies and production jar bundling as a one-liner.
    fromCommon ':common'
}
```

More complicated usage example from Arch API: https://github.com/Juuxel/architectury-api/commit/39de89cf0d5941fd66f728ff52be479e06817a19

Note about the version: this isn't a breaking change, but it's a good chance to introduce some cleanup breaking changes, like removing unused properties and simplifying the extension class.