### PR TITLE
fix gradle >8.12 compatibility

### DIFF
--- a/src/main/kotlin/dev/architectury/plugin/TransformingTask.kt
+++ b/src/main/kotlin/dev/architectury/plugin/TransformingTask.kt
@@ -79,6 +79,10 @@ open class TransformingTask : Jar() {
         }
     }
 
+    override fun copy() {
+        // do nothing
+    }
+
     private fun ClassNode.toByteArray(): ByteArray {
         val writer = ClassWriter(0)
         this.accept(writer)


### PR DESCRIPTION
For some reason the task action order has changed in gradle >8.12

On <=8.11, the transform task action executes _after_ the copy action (this task extends the Jar task which adds the copy action)

But on 8.12 the transform action executes _before_ the copy action.
which wipes the now transformed output jar back to an empty state.

The transform task is already copying and transforming jar contents, it doesn't need this extra copy action.
So what it executes can just be no-op'd 

